### PR TITLE
fix: handle subpaths in menu entries navigation

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -120,7 +120,9 @@ const Container: React.FC<{
 		} catch {}
 	};
 
-	const current = MenuEntries.findIndex(([, path]) => location === path);
+	const current = MenuEntries.findIndex(
+		([, path]) => location === path || location.startsWith("${path}" + "/"),
+	);
 	const next = get.next(MenuEntries, current)[1];
 	const prev = get.prev(MenuEntries, current)[1];
 	const end = current === MenuEntries.length - 1;

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -121,7 +121,7 @@ const Container: React.FC<{
 	};
 
 	const current = MenuEntries.findIndex(
-		([, path]) => location === path || location.startsWith("${path}" + "/"),
+		([, path]) => location === path || location.startsWith(path + "/"),
 	);
 	const next = get.next(MenuEntries, current)[1];
 	const prev = get.prev(MenuEntries, current)[1];


### PR DESCRIPTION
Add subpath handling for current navigation index retrieval, fixing a bug where navigating from the 'experience' section incorrectly directed to the previous screen instead of the next one.